### PR TITLE
Add /ping

### DIFF
--- a/Boolean/Modules/BotInfo.cs
+++ b/Boolean/Modules/BotInfo.cs
@@ -17,4 +17,16 @@ public class BotInfo(DiscordSocketClient client, BotConfig config) : Interaction
         
         await RespondAsync(embed: embed.Build(), ephemeral: true);
     }
+    
+    [SlashCommand("ping", "Gets the current client latency.")]
+    public async Task Ping()
+    {
+        var embed = new EmbedBuilder()
+        {
+            Title = "Ping",
+            Description = $"Pong. Took **{client.Latency}ms** to respond."
+        }.WithColor(config.BotTheme);
+        
+        await RespondAsync(embed: embed.Build(), ephemeral: true);
+    }
 }


### PR DESCRIPTION
Added the /ping command, to respond with the current DiscordSocketClient's Latency field. See issue #9 