### PR TITLE
Add Migrations to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -486,3 +486,5 @@ Boolean/appsettings.json
 
 # The compiled code
 out
+
+Migrations/


### PR DESCRIPTION
I am sick to death of dealing with git errors because of Migrations/*.cs
