### PR TITLE
/help and join messages #43

### DIFF
--- a/Boolean/Config.cs
+++ b/Boolean/Config.cs
@@ -7,6 +7,21 @@ public class Config
     public required string DiscordToken { get; set; }
     public required DatabaseCredentials DbCredentials { get; set; }
     
+    // Discord flattens whitespace, use "\u2800" to create whitespace
+    // https://www.compart.com/en/unicode/U+2800
+    public class Strings
+    {   // might be a good idea to switch this to a Pageination when issue #32 is complete 
+        public static string  HelpMsg = "__**/set channel <purpose>**__\n" +
+                                 "\u2800Marks a channel for a specific purpose, such as for welcoming messages, starboard, server logs, etc\n" +
+                                 "__**/unset channel <purpose>**__\n" +
+                                 "\u2800Unmarks a channel from a specific purpose\n"; // send by /help
+        // Written by dyslexic Kventis, might be an idea to rewrite before merge
+        public static string JoinMsg = "Before we get to the good bits, may I suggest taking a look at the /help command for help with configuration? " +
+                                       "Here are some I think you should definitely take a look at.\n\n" +
+                                       "__**/set channel <purpose>**__\n" +
+                                       "\u2800Marks a channel for a specific purpose, such as for welcoming messages, starboard, server logs, etc\n" +
+                                       ""; // this message is sent when Boolean joins a guild
+    }
     #if DEBUG
         public required ulong TestGuildId { get; set; }
     #endif

--- a/Boolean/EventHandlers.cs
+++ b/Boolean/EventHandlers.cs
@@ -1,7 +1,10 @@
+using Boolean.Util;
 using Discord;
 using Discord.Commands;
 using Discord.Interactions;
 using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Boolean;
 
@@ -33,5 +36,24 @@ public class EventHandlers(IServiceProvider serviceProvider, Config config, Disc
    {
        var ctx = new SocketInteractionContext(client, interaction);
        return interactionService.ExecuteCommandAsync(ctx, serviceProvider);
+   }
+
+   // Tries to send to the default channel, if lacking permissions search all channels until you find one
+   public async Task GuildCreate(SocketGuild guild)
+   {
+       ITextChannel? target = guild.DefaultChannel;
+       var permissions = guild.CurrentUser.GetPermissions(target);
+       if (permissions.SendMessages == false) 
+           // Find first channel that is text and permission to send messages
+           target = guild.Channels.FirstOrDefault(c =>
+               c.GetChannelType() == ChannelType.Text && guild.CurrentUser.GetPermissions(c).SendMessages) as ITextChannel;
+       if (target == null) return; // give up :(
+       EmbedBuilder embed = new EmbedBuilder()
+       {
+           Color = EmbedColors.Normal,
+           Title = $"Thanks for adding me to {guild.Name}!",
+           Description = Config.Strings.JoinMsg,
+       };
+       await target.SendMessageAsync(embed: embed.Build());
    }
 }

--- a/Boolean/EventHandlers.cs
+++ b/Boolean/EventHandlers.cs
@@ -3,8 +3,6 @@ using Discord;
 using Discord.Commands;
 using Discord.Interactions;
 using Discord.WebSocket;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Boolean;
 

--- a/Boolean/Modules/BotInfo.cs
+++ b/Boolean/Modules/BotInfo.cs
@@ -2,6 +2,7 @@ using Boolean.Util;
 using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
 
 namespace Boolean;
 
@@ -28,6 +29,18 @@ public class BotInfo(DiscordSocketClient client) : InteractionModuleBase<SocketI
             Description = $"Pong. Took **{client.Latency}ms** to respond"
         };
         
+        await RespondAsync(embed: embed.Build(), ephemeral: true);
+    }
+
+    [SlashCommand("help", "Explains what can be configured in Boolean")]
+    public async Task Help()
+    {
+        var embed = new EmbedBuilder
+        {
+            Title = "Configuration help",
+            Description = Config.Strings.HelpMsg,
+            Color = EmbedColors.Normal,
+        };
         await RespondAsync(embed: embed.Build(), ephemeral: true);
     }
 }

--- a/Boolean/Modules/BotInfo.cs
+++ b/Boolean/Modules/BotInfo.cs
@@ -2,7 +2,6 @@ using Boolean.Util;
 using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
-using Microsoft.Extensions.Configuration;
 
 namespace Boolean;
 

--- a/Boolean/Program.cs
+++ b/Boolean/Program.cs
@@ -54,5 +54,6 @@ class Program
         _client.Log += eventHandlers.LogMessage;
         _client.Ready += eventHandlers.Ready;
         _client.InteractionCreated += eventHandlers.InteractionCreated;
+        _client.JoinedGuild += eventHandlers.GuildCreate;
     }
 }


### PR DESCRIPTION
For issue #43.
Upon joining a new guild a help message is sent to the default channel or the first text channel with send permissions. This join message might need some touching up.
/help provides a list of commands that can be configured.
Both strings can be found in Config.cs under the static Strings class